### PR TITLE
[Simplex::ineqType] support AdjEq

### DIFF
--- a/mlir/lib/Analysis/Presburger/Simplex.cpp
+++ b/mlir/lib/Analysis/Presburger/Simplex.cpp
@@ -165,6 +165,12 @@ inline Simplex::IneqType Simplex::separationType(unsigned row) {
   if (tableau(row, 0) != 1)
     return IneqType::Separate;
 
+  if (tableau(row, 1) == -1) {
+    auto min = computeRowOptimum(Direction::Down, row);
+    if (min && *min == Fraction(-1, 1))
+      return IneqType::AdjEq;
+  }
+
   bool found = false;
   for (unsigned col = liveColBegin; col < nCol; col++) {
     if (tableau(row, col) != 0) {
@@ -180,8 +186,6 @@ inline Simplex::IneqType Simplex::separationType(unsigned row) {
 
   if (found)
     return IneqType::AdjIneq;
-  else if (tableau(row, 1) == -1)
-    return IneqType::AdjEq;
   else
     return IneqType::Separate;
 }

--- a/mlir/lib/Analysis/Presburger/Simplex.cpp
+++ b/mlir/lib/Analysis/Presburger/Simplex.cpp
@@ -165,12 +165,6 @@ inline Simplex::IneqType Simplex::separationType(unsigned row) {
   if (tableau(row, 0) != 1)
     return IneqType::Separate;
 
-  if (tableau(row, 1) == -1) {
-    auto min = computeRowOptimum(Direction::Down, row);
-    if (min && *min == Fraction(-1, 1))
-      return IneqType::AdjEq;
-  }
-
   bool found = false;
   for (unsigned col = liveColBegin; col < nCol; col++) {
     if (tableau(row, col) != 0) {
@@ -182,6 +176,12 @@ inline Simplex::IneqType Simplex::separationType(unsigned row) {
         return IneqType::Separate;
       }
     }
+  }
+
+  if (tableau(row, 1) == -1) {
+    auto min = computeRowOptimum(Direction::Down, row);
+    if (min && *min == Fraction(-1, 1))
+      return IneqType::AdjEq;
   }
 
   if (found)

--- a/mlir/unittests/Analysis/Presburger/SimplexTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/SimplexTest.cpp
@@ -361,6 +361,10 @@ TEST(SimplexTest, ineqType) {
   Simplex simplex2(1);
   simplex2.addInequality({1, -1}); // x >= 1.
   EXPECT_EQ(simplex2.ineqType({-1, 0}), Simplex::IneqType::AdjIneq); // x <= 0.
+  Simplex simplex3(1);
+  simplex3.addInequality({1, -2}); // x >= 2.
+  simplex3.addInequality({-1, 3}); // x <= 3.
+  EXPECT_EQ(simplex3.ineqType({-1, 1}), Simplex::IneqType::AdjIneq);
 }
 
 TEST(SimplexTest, getSamplePointIfIntegral) {

--- a/mlir/unittests/Analysis/Presburger/SimplexTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/SimplexTest.cpp
@@ -354,6 +354,15 @@ TEST(SimplexTest, isUnbounded) {
                    .isUnbounded());
 }
 
+TEST(SimplexTest, ineqType) {
+  Simplex simplex(1);
+  simplex.addEquality({1, 0}); // x >= 0.
+  EXPECT_EQ(simplex.ineqType({1, -1}), Simplex::IneqType::AdjEq); // x >= 1.
+  Simplex simplex2(1);
+  simplex2.addInequality({1, -1}); // x >= 1.
+  EXPECT_EQ(simplex2.ineqType({-1, 0}), Simplex::IneqType::AdjIneq); // x <= 0.
+}
+
 TEST(SimplexTest, getSamplePointIfIntegral) {
   // Empty set.
   EXPECT_FALSE(simplexFromConstraints(3,


### PR DESCRIPTION
@webmiche, this seems to break some coalescing tests. Can you check if this is because of the workaround for AdjEq that was used?