### PR TITLE
Feature Presburger expression lowering

### DIFF
--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -180,7 +180,7 @@ def ConvertLinalgToSPIRV : Pass<"convert-linalg-to-spirv", "ModuleOp"> {
 // PresburgerToStandard
 //===----------------------------------------------------------------------===//
 
-def ConvertPresburgerToStandard : Pass<"convert-presburger-to-std"> {
+def ConvertPresburgerToStandard : Pass<"convert-presburger-to-std", "ModuleOp"> {
   let summary = "Convert the Presburger dialect to Standard dialect";
   let constructor = "mlir::createPresburgerToStandardPass()";
 }

--- a/mlir/include/mlir/Dialect/Presburger/PresburgerOps.td
+++ b/mlir/include/mlir/Dialect/Presburger/PresburgerOps.td
@@ -232,4 +232,31 @@ def Presburger_ContainsOp : Presburger_Op<"contains", [NoSideEffect]> {
 
 }
 
+def Presburger_ApplyOp : Presburger_Op<"apply", [NoSideEffect]> {
+    let summary = "applies a Presburger expression to the specified parameters";
+
+    let description = [{
+        The presburger.apply operation applies the specified Presburger
+        expression to the provided parameters. 
+
+        All the provided SSA values - except the Presburger expression - 
+        must all have `index` type.
+
+        TODO define what happens if point isn't contained in a domain 
+
+        Example:
+
+        ```mlir
+        %expr = presburger.expr #presburger<"expr (x)[s] -> (x + s) : (x >= 0) ; (0) : (-x + 1 >= 0)">
+        ...
+
+        %contained = presburger.apply (%d1)[%s1] %expr 
+        ```
+    }];
+
+    let arguments = (ins Variadic<Index>:$dimAndSyms, PresburgerExprType:$expr);
+
+    let results = (outs Index:$res);
+
+}
 #endif // Presburger_OPS

--- a/mlir/test/Conversion/PresburgerToStandard/convert-presburger-to-standard.mlir
+++ b/mlir/test/Conversion/PresburgerToStandard/convert-presburger-to-standard.mlir
@@ -75,12 +75,14 @@ func @contains_runtime(%x0 : index, %x1 : index, %s0 : index) -> i1 {
 // presburger.apply
 //-----------------------------------------------------------------------------
 
+// TODO: these tests might be too specific
+
 // CHECK-LABEL: func @simple_apply(%arg0: index) -> index {
 // CHECK-NEXT:    %{{.*}} = presburger.expr #presburger<"{{.*}}">
 // CHECK-NEXT:    br ^bb2
 // CHECK-NEXT:  ^bb1(%1: index):  
 // CHECK-NEXT:    return %1 : index
-// CHECK-NEXT:  ^bb2:  // pred: ^bb0
+// CHECK-NEXT:  ^bb2:  
 // CHECK-NEXT:    %true = constant true
 // CHECK-NEXT:    %c0 = constant 0 : index
 // CHECK-NEXT:    cond_br %true, ^bb3, ^bb1(%c0 : index)
@@ -94,6 +96,82 @@ func @contains_runtime(%x0 : index, %x1 : index, %s0 : index) -> i1 {
 func @simple_apply(%d1 : index) -> index {
 
   %expr1 = presburger.expr #presburger<"expr(x)[] -> (x) : ()">
+  %c1 = presburger.apply (%d1)[] %expr1 
+
+  return %c1 : index
+}
+
+
+// CHECK-LABEL: func @expression_apply(%arg0: index) -> index {
+// CHECK-NEXT:    %0 = presburger.expr #presburger<"{{.*}}">
+// CHECK-NEXT:    br ^bb2
+// CHECK-NEXT:  ^bb1(%1: index):  
+// CHECK-NEXT:    return %1 : index
+// CHECK-NEXT:  ^bb2:  
+// CHECK-NEXT:    %true = constant true
+// CHECK-NEXT:    %c0 = constant 0 : index
+// CHECK-NEXT:    cond_br %true, ^bb3, ^bb1(%c0 : index)
+// CHECK-NEXT:  ^bb3:  
+// CHECK-NEXT:    %c10 = constant 10 : index
+// CHECK-NEXT:    %c2 = constant 2 : index
+// CHECK-NEXT:    %2 = muli %c2, %arg0 : index
+// CHECK-NEXT:    %3 = addi %c10, %2 : index
+// CHECK-NEXT:    br ^bb1(%3 : index)
+// CHECK-NEXT:  }
+func @expression_apply(%d1 : index) -> index {
+
+  %expr1 = presburger.expr #presburger<"expr(x)[] -> (2x + 10) : ()">
+  %c1 = presburger.apply (%d1)[] %expr1 
+
+  return %c1 : index
+}
+
+// CHECK-LABEL:  func @two_domain_apply(%arg0: index) -> index {
+// CHECK-NEXT:    %0 = presburger.expr #presburger<"{{.*}}">
+// CHECK-NEXT:    br ^bb2
+// CHECK-NEXT:  ^bb1(%1: index):  
+// CHECK-NEXT:    return %1 : index
+// CHECK-NEXT:  ^bb2:  
+// CHECK-NEXT:    %false = constant false
+// CHECK-NEXT:    %true = constant true
+// CHECK-NEXT:    %c0 = constant 0 : index
+// CHECK-NEXT:    %c-1 = constant -1 : index
+// CHECK-NEXT:    %2 = muli %c-1, %arg0 : index
+// CHECK-NEXT:    %3 = addi %c0, %2 : index
+// CHECK-NEXT:    %c0_0 = constant 0 : index
+// CHECK-NEXT:    %4 = cmpi "sge", %3, %c0_0 : index
+// CHECK-NEXT:    %5 = and %true, %4 : i1
+// CHECK-NEXT:    %6 = or %false, %5 : i1
+// CHECK-NEXT:    cond_br %6, ^bb3, ^bb4
+// CHECK-NEXT:  ^bb3: 
+// CHECK-NEXT:    %c1 = constant 1 : index
+// CHECK-NEXT:    %c1_1 = constant 1 : index
+// CHECK-NEXT:    %7 = muli %c1_1, %arg0 : index
+// CHECK-NEXT:    %8 = addi %c1, %7 : index
+// CHECK-NEXT:    br ^bb1(%8 : index)
+// CHECK-NEXT:  ^bb4:
+// CHECK-NEXT:    %false_2 = constant false
+// CHECK-NEXT:    %true_3 = constant true
+// CHECK-NEXT:    %c-1_4 = constant -1 : index
+// CHECK-NEXT:    %c1_5 = constant 1 : index
+// CHECK-NEXT:    %9 = muli %c1_5, %arg0 : index
+// CHECK-NEXT:    %10 = addi %c-1_4, %9 : index
+// CHECK-NEXT:    %c0_6 = constant 0 : index
+// CHECK-NEXT:    %11 = cmpi "sge", %10, %c0_6 : index
+// CHECK-NEXT:    %12 = and %true_3, %11 : i1
+// CHECK-NEXT:    %13 = or %false_2, %12 : i1
+// CHECK-NEXT:    %c0_7 = constant 0 : index
+// CHECK-NEXT:    cond_br %13, ^bb5, ^bb1(%c0_7 : index)
+// CHECK-NEXT:  ^bb5:
+// CHECK-NEXT:    %c-10 = constant -10 : index
+// CHECK-NEXT:    %c1_8 = constant 1 : index
+// CHECK-NEXT:    %14 = muli %c1_8, %arg0 : index
+// CHECK-NEXT:    %15 = addi %c-10, %14 : index
+// CHECK-NEXT:    br ^bb1(%15 : index)
+// CHECK-NEXT:  }
+func @two_domain_apply(%d1 : index) -> index {
+
+  %expr1 = presburger.expr #presburger<"expr(x)[] -> (x + 1) : (x <= 0); (x - 10) : (x >= 1)">
   %c1 = presburger.apply (%d1)[] %expr1 
 
   return %c1 : index

--- a/mlir/test/Conversion/PresburgerToStandard/convert-presburger-to-standard.mlir
+++ b/mlir/test/Conversion/PresburgerToStandard/convert-presburger-to-standard.mlir
@@ -1,5 +1,21 @@
 // RUN: mlir-opt --convert-presburger-to-std %s | FileCheck %s
 
+//-----------------------------------------------------------------------------
+// presburger.contains
+//-----------------------------------------------------------------------------
+
+// CHECK-LABEL: func @contains_universe(%arg0: index) -> i1 {
+// CHECK-NEXT:    {{.*}} = presburger.set #presburger<"{{.*}}">
+// CHECK-NEXT:    %true = constant true
+// CHECK-NEXT:    return %true : i1
+// CHECK-NEXT:  }
+func @contains_universe(%x0 : index) -> i1 {
+  %set1 = presburger.set #presburger<"set(x)[] : ()">
+
+  %c = presburger.contains (%x0)[] %set1
+  return %c : i1
+}
+
 // -----
 
 // CHECK-LABEL: func @contains_runtime
@@ -53,4 +69,32 @@ func @contains_runtime(%x0 : index, %x1 : index, %s0 : index) -> i1 {
 
   %c = presburger.contains (%x0, %x1)[%s0] %set1
   return %c : i1
+}
+
+//-----------------------------------------------------------------------------
+// presburger.apply
+//-----------------------------------------------------------------------------
+
+// CHECK-LABEL: func @simple_apply(%arg0: index) -> index {
+// CHECK-NEXT:    %{{.*}} = presburger.expr #presburger<"{{.*}}">
+// CHECK-NEXT:    br ^bb2
+// CHECK-NEXT:  ^bb1(%1: index):  
+// CHECK-NEXT:    return %1 : index
+// CHECK-NEXT:  ^bb2:  // pred: ^bb0
+// CHECK-NEXT:    %true = constant true
+// CHECK-NEXT:    %c0 = constant 0 : index
+// CHECK-NEXT:    cond_br %true, ^bb3, ^bb1(%c0 : index)
+// CHECK-NEXT:  ^bb3:  
+// CHECK-NEXT:    %c0_0 = constant 0 : index
+// CHECK-NEXT:    %c1 = constant 1 : index
+// CHECK-NEXT:    %2 = muli %c1, %arg0 : index
+// CHECK-NEXT:    %3 = addi %c0_0, %2 : index
+// CHECK-NEXT:    br ^bb1(%3 : index)
+// CHECK-NEXT:  }
+func @simple_apply(%d1 : index) -> index {
+
+  %expr1 = presburger.expr #presburger<"expr(x)[] -> (x) : ()">
+  %c1 = presburger.apply (%d1)[] %expr1 
+
+  return %c1 : index
 }

--- a/mlir/test/Dialect/Presburger/apply.mlir
+++ b/mlir/test/Dialect/Presburger/apply.mlir
@@ -1,0 +1,32 @@
+// RUN: mlir-opt %s --mlir-print-op-generic | mlir-opt | FileCheck %s
+
+func @simple_apply() {
+
+  // CHECK: %[[S1:.*]] = presburger.expr #presburger<"{{.*}}">
+  %expr1 = presburger.expr #presburger<"expr(x)[] -> (x) : ()">
+
+  // CHECK: %[[D1:.*]] = constant 0 : index
+  %d1 = constant 0 : index
+
+  // CHECK: %{{.*}} = presburger.apply (%[[D1]]) %[[S1]]
+  %c1 = presburger.apply (%d1)[] %expr1 
+
+  return
+}
+
+// -----
+
+func @simple_apply_with_syms() {
+
+  // CHECK: %[[S1:.*]] = presburger.expr #presburger<"{{.*}}">
+  %set1 = presburger.expr #presburger<"expr(x)[s] -> (x + s) : (x >= s) ; (x) : (x - 1 <= s)">
+
+  // CHECK: %[[D1:.*]] = constant 0 : index
+  %d1 = constant 0 : index
+  // CHECK: %[[P1:.*]] = constant 1 : index
+  %s1 = constant 1 : index
+
+  // CHECK: %{{.*}} = presburger.apply (%[[D1]])[%[[P1]]] %[[S1]]
+  %uset = presburger.apply (%d1)[%s1] %set1 
+  return
+}


### PR DESCRIPTION
This PR contains the the `presburger.apply` operation and its lowering. 

The operation allows to apply the provided expression to parameters. 

The lowering generates code that goes over all domains and checks if the provided point is contained in it. If this is the case, it evaluates the according expression under the given parameters, otherwise it checks the next domain. 

If no domain contains the point, it evaluates to 0. I was not sure what else makes sense. 