### PR TITLE
Patch coalesce

### DIFF
--- a/mlir/include/mlir/Analysis/Presburger/Coalesce.h
+++ b/mlir/include/mlir/Analysis/Presburger/Coalesce.h
@@ -1,0 +1,16 @@
+#include "mlir/Analysis/AffineStructures.h"
+#include "mlir/Analysis/Presburger/Simplex.h"
+#include "mlir/Analysis/PresburgerSet.h"
+
+namespace mlir {
+
+/// coalesces a set according to the "integer set coalescing" by sven
+/// verdoolaege.
+///
+/// Coalescing takes two convex BasicSets and tries to figure out, whether the
+/// convex hull of those two BasicSets is the same integer set as the union of
+/// those two BasicSets and if so, tries to come up with a BasicSet
+/// corresponding to this convex hull.
+PresburgerSet coalesce(PresburgerSet &set);
+
+} // namespace mlir

--- a/mlir/include/mlir/Analysis/Presburger/Simplex.h
+++ b/mlir/include/mlir/Analysis/Presburger/Simplex.h
@@ -234,6 +234,9 @@ public:
   void print(raw_ostream &os) const;
   void dump() const;
 
+  /// Check if the given constraint is redundant
+  bool isRedundant(ArrayRef<int64_t> coeffs);
+
 private:
   friend class GBRSimplex;
 

--- a/mlir/lib/Analysis/Presburger/CMakeLists.txt
+++ b/mlir/lib/Analysis/Presburger/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_library(MLIRPresburger
   Simplex.cpp
   Matrix.cpp
+  Coalesce.cpp
   )

--- a/mlir/lib/Analysis/Presburger/Coalesce.cpp
+++ b/mlir/lib/Analysis/Presburger/Coalesce.cpp
@@ -40,11 +40,12 @@ PresburgerSet mlir::coalesce(PresburgerSet &set) {
         marked[j] = true;
       }
     }
-
-    if (!marked[i]) {
-      newSet.unionFACInPlace(bs1);
-    }
   }
 
+  for (unsigned i = 0; i < basicSetVector.size(); ++i) {
+    if (!marked[i]) {
+      newSet.unionFACInPlace(basicSetVector[i]);
+    }
+  }
   return newSet;
 }

--- a/mlir/lib/Analysis/Presburger/Coalesce.cpp
+++ b/mlir/lib/Analysis/Presburger/Coalesce.cpp
@@ -1,0 +1,50 @@
+#include "mlir/Analysis/Presburger/Coalesce.h"
+#include "mlir/Analysis/AffineStructures.h"
+#include "mlir/Analysis/Presburger/Simplex.h"
+#include "mlir/Analysis/PresburgerSet.h"
+
+using namespace mlir;
+
+/// eliminates FlatAffineConstraints, that are fully contained within other
+/// FlatAffineConstraints, from the representation of set
+PresburgerSet mlir::coalesce(PresburgerSet &set) {
+  PresburgerSet newSet =
+      PresburgerSet::getEmptySet(set.getNumDims(), set.getNumSyms());
+  ArrayRef<FlatAffineConstraints> basicSetVector =
+      set.getAllFlatAffineConstraints();
+  SmallVector<bool, 4> marked(set.getNumFACs());
+
+  for (unsigned i = 0; i < basicSetVector.size(); i++) {
+    if (marked[i])
+      continue;
+    FlatAffineConstraints bs1 = basicSetVector[i];
+
+    unsigned numIneq = bs1.getNumInequalities();
+    unsigned numEq = bs1.getNumEqualities();
+    // check if bs1 is contained in any basicSet
+    for (unsigned j = 0; j < basicSetVector.size(); j++) {
+      if (j == i || marked[j])
+        continue;
+      FlatAffineConstraints bs2 = basicSetVector[j];
+      Simplex simplex(bs2);
+
+      bool contained = true;
+      for (unsigned i = 0; i < numIneq; ++i) {
+        contained &= simplex.isRedundant(bs1.getInequality(i));
+      }
+      for (unsigned i = 0; i < numEq; ++i) {
+        contained &= simplex.isRedundant(bs1.getEquality(i));
+      }
+
+      if (contained) {
+        marked[j] = true;
+      }
+    }
+
+    if (!marked[i]) {
+      newSet.unionFACInPlace(bs1);
+    }
+  }
+
+  return newSet;
+}

--- a/mlir/lib/Analysis/Presburger/Simplex.cpp
+++ b/mlir/lib/Analysis/Presburger/Simplex.cpp
@@ -1195,4 +1195,9 @@ void Simplex::print(raw_ostream &os) const {
 
 void Simplex::dump() const { print(llvm::errs()); }
 
+bool Simplex::isRedundant(ArrayRef<int64_t> coeffs) {
+  Optional<Fraction> minimum = computeOptimum(Direction::Down, coeffs);
+  return minimum && *minimum >= Fraction(0, 1);
+}
+
 } // namespace mlir

--- a/mlir/unittests/Analysis/Presburger/CMakeLists.txt
+++ b/mlir/unittests/Analysis/Presburger/CMakeLists.txt
@@ -1,8 +1,10 @@
 add_mlir_unittest(MLIRPresburgerTests
   MatrixTest.cpp
   SimplexTest.cpp
+  CoalesceTest.cpp
 )
 
 target_link_libraries(MLIRPresburgerTests
-  PRIVATE MLIRPresburger)
+  PRIVATE MLIRPresburger
+  MLIRLoopAnalysis)
 

--- a/mlir/unittests/Analysis/Presburger/CoalesceTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/CoalesceTest.cpp
@@ -1,0 +1,94 @@
+#include "mlir/Analysis/Presburger/Coalesce.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace mlir {
+
+/// Construct a FlatAffineConstraints from a set of inequality and
+/// equality constraints.
+static FlatAffineConstraints
+makeFACFromConstraints(unsigned dims, ArrayRef<SmallVector<int64_t, 4>> ineqs,
+                       ArrayRef<SmallVector<int64_t, 4>> eqs) {
+  FlatAffineConstraints fac(ineqs.size(), eqs.size(), dims + 1, dims);
+  for (const SmallVector<int64_t, 4> &eq : eqs)
+    fac.addEquality(eq);
+  for (const SmallVector<int64_t, 4> &ineq : ineqs)
+    fac.addInequality(ineq);
+  return fac;
+}
+
+static FlatAffineConstraints
+makeFACFromIneqs(unsigned dims, ArrayRef<SmallVector<int64_t, 4>> ineqs) {
+  return makeFACFromConstraints(dims, ineqs, {});
+}
+
+static PresburgerSet makeSetFromFACs(unsigned dims,
+                                     ArrayRef<FlatAffineConstraints> facs) {
+  PresburgerSet set = PresburgerSet::getEmptySet(dims);
+  for (const FlatAffineConstraints &fac : facs)
+    set.unionFACInPlace(fac);
+  return set;
+}
+
+void expectCoalesce(size_t expectedNumBasicSets, PresburgerSet set) {
+  PresburgerSet newSet = coalesce(set);
+  set.dump();
+  newSet.dump();
+  EXPECT_TRUE(set.isEqual(newSet));
+  EXPECT_TRUE(expectedNumBasicSets == newSet.getNumFACs());
+}
+
+TEST(CoalesceTest, containedOneDim) {
+  PresburgerSet set =
+      makeSetFromFACs(1, {
+                             makeFACFromIneqs(1, {{1, 0},    // x >= 0.
+                                                  {-1, 4}}), // x <= 4.
+                             makeFACFromIneqs(1, {{1, -1},   // x >= 1.
+                                                  {-1, 2}}), // x <= 2.
+                         });
+  expectCoalesce(1, set);
+}
+
+TEST(CoalesceTest, separateOneDim) {
+  PresburgerSet set =
+      makeSetFromFACs(1, {
+                             makeFACFromIneqs(1, {{1, 0},    // x >= 0.
+                                                  {-1, 2}}), // x <= 2.
+                             makeFACFromIneqs(1, {{1, -3},   // x >= 3.
+                                                  {-1, 4}}), // x <= 4.
+                         });
+  expectCoalesce(2, set);
+}
+
+TEST(CoalesceTest, separateTwoDim) {
+  PresburgerSet set =
+      makeSetFromFACs(2, {
+                             makeFACFromIneqs(2, {{1, 0, 0},    // x >= 0.
+                                                  {-1, 0, 3},   // x <= 3.
+                                                  {0, 1, 0},    // y >= 0
+                                                  {0, -1, 1}}), // y <= 1.
+                             makeFACFromIneqs(2, {{1, 0, 0},    // x >= 0.
+                                                  {-1, 0, 3},   // x <= 3.
+                                                  {0, 1, -2},   // y >= 2.
+                                                  {0, -1, 3}}), // y <= 3
+                         });
+  expectCoalesce(2, set);
+}
+
+TEST(CoalesceTest, containedTwoDim) {
+  PresburgerSet set =
+      makeSetFromFACs(2, {
+                             makeFACFromIneqs(2, {{1, 0, 0},    // x >= 0.
+                                                  {-1, 0, 3},   // x <= 3.
+                                                  {0, 1, 0},    // y >= 0
+                                                  {0, -1, 3}}), // y <= 3.
+                             makeFACFromIneqs(2, {{1, 0, 0},    // x >= 0.
+                                                  {-1, 0, 3},   // x <= 3.
+                                                  {0, 1, -2},   // y >= 2.
+                                                  {0, -1, 3}}), // y <= 3
+                         });
+  expectCoalesce(1, set);
+}
+
+} // namespace mlir

--- a/mlir/unittests/Analysis/Presburger/SimplexTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/SimplexTest.cpp
@@ -383,4 +383,17 @@ TEST(SimplexTest, addInequality_already_redundant) {
   EXPECT_TRUE(simplex.isMarkedRedundant(1));
 }
 
+TEST(SimplexTest, isRedundant) {
+  Simplex simplex(2);
+  simplex.addInequality({0, -1, 1}); // [0]: y <= 1.
+  simplex.addInequality({1, 0, -1}); // [1]: x >= 1.
+  simplex.addEquality({-1, 1, 0});   // [2]: y = x.
+
+  EXPECT_TRUE(simplex.isRedundant({-1, 0, 2})); // x <= 2.
+  EXPECT_TRUE(simplex.isRedundant({0, 1, 0}));  // y >= 0.
+
+  EXPECT_FALSE(simplex.isRedundant({-1, 0, -1})); // x <= -1.
+  EXPECT_FALSE(simplex.isRedundant({0, 1, -2}));  // y >= 2.
+}
+
 } // namespace mlir


### PR DESCRIPTION
The first patch for coalesce. This only applies the `redundant` heuristic, i.e., it checks for sets that are contained in others and deletes those.